### PR TITLE
Fix auto merge config (skip Tide's check)

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,9 +1,12 @@
 name: dependabot-auto-merge
 
 on:
-  check_suite:
+  workflow_run:
     types:
       - completed
+    workflows:
+      # List all required workflow names here.
+      - "Build and test"
 
 jobs:
   merge-me:
@@ -11,6 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Merge me!
+        if: ${{ github.event.workflow_run.conclusion == 'success' }}
         uses: ridedott/merge-me-action@v2
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What?
- Fix auto merge config (skip Tide's check)

## Why?
- 現在 Prow によって自動でマージされるには lgtm ラベルと approved ラベルが必要だが，その判定が check suite の一部として実行される． なので，check_suite が一向に completed 状態にならず自動マージ用のアクションがトリガーされなかった