### PR TITLE
Disable to deploying template

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -6,7 +6,7 @@ jobs:
   hook:
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    if: github.actor != 'dependabot[bot]'
+    if: github.actor != 'dependabot[bot]' && !contains(github.repository, "template")
     steps:
       - name: Repository Dispatch
         uses: peter-evans/repository-dispatch@v1


### PR DESCRIPTION
## What?
Disable to deploying template

## Why?
テンプレートはデプロイする必要がないので

## See also 
Related to https://github.com/dataware-tools/api-template-nestjs/pull/26